### PR TITLE
Fixed: When a product has no image assigned, Catalog feed sending the…

### DIFF
--- a/Model/Feed.php
+++ b/Model/Feed.php
@@ -530,21 +530,20 @@ class Feed implements FeedInterface
                 $images[$key] = $this->_helper->fixLink($value);
 
             $thumbnailNumber = $this->_helper->getThumbnailNumber($storeIds[0]);
+            $image = '';
             foreach ($storeIds as $storeId){
                 if (isset($images[$storeId][$thumbnailNumber])) {
                     $image = $images[$storeId][$thumbnailNumber];
                     break;
                 }
             }
-            if (isset($image)){
+            if (!empty($image)){
                 foreach ($storeIds as $storeId){
                     if (isset($images[$storeId][$thumbnailNumber])) {
                         unset($images[$storeId][$thumbnailNumber]);
                     }
                 }
             }
-            else
-                $image = '';
 
             $alternativeImages = array();
             foreach ($storeIds as $storeId){


### PR DESCRIPTION
Magento2 - AllWall - When a product has no image assigned, the catalog feed will send the image URL of the previous product.