### PR TITLE
FourTell_Recommend-2.2019.2.4 Installation issue

### DIFF
--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -18,7 +18,7 @@ class InstallData implements InstallDataInterface
         $this->eavConfig       = $eavConfig;
     }
  
-    public function upgrade(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
+    public function install(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
     {
 
     }


### PR DESCRIPTION
Fixed: PHP Fatal error:  Class FourTell\Recommend\Setup\InstallData
contains 1 abstract method and must therefore be declared abstract